### PR TITLE
StatusOr append to status message.

### DIFF
--- a/absl/status/statusor.h
+++ b/absl/status/statusor.h
@@ -547,6 +547,9 @@ class StatusOr : private internal_statusor::StatusOrData<T>,
   // complaints from any tools that are checking that errors are not dropped on
   // the floor.
   void IgnoreError() const;
+  void append_status_message(const std::string& additional) {
+	this->status_.AppendToMessage(additional);
+  }
 
   // StatusOr<T>::emplace()
   //


### PR DESCRIPTION
StatusOr should be able to append to status message to propagate message up the call chain.

Thank you for your contribution to Abseil!

Before submitting this PR, please be sure to read our [contributing
guidelines](https://github.com/abseil/abseil-cpp/blob/master/CONTRIBUTING.md).

If you are a Googler, please also note that it is required that you send us a
Piper CL instead of using the GitHub pull-request process. The code propagation
process will deliver the change to GitHub.
